### PR TITLE
Update nonsteam.py - Fix for line 452.

### DIFF
--- a/nonsteam.py
+++ b/nonsteam.py
@@ -449,7 +449,7 @@ def non_steam_shortcuts():
         # Create/Update Non-Steam shortcut
         play_action_expanded = PlayniteApi.ExpandGameVariables(game, play_action)
         if play_action_expanded.Type == GameActionType.Emulator:
-            emulator = PlayniteApi.Database.GetEmulator(play_action.EmulatorId)
+            emulator = PlayniteApi.Database.Emulators.Get(play_action.EmulatorId)
             if emulator.Profiles:
                 profile = emulator.Profiles.FirstOrDefault(lambda a: a.Id == play_action.EmulatorProfileId)
             else:


### PR DESCRIPTION
Fixes the 'Database API' object has no attribute 'GetEmulator' error. Presumably the syntax of the get function changed with future releases of Playnite.